### PR TITLE
Add build script to generate a blog post starter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY=post
+
+post:
+	@./bin/generate_blog_post.sh

--- a/bin/generate_blog_post.sh
+++ b/bin/generate_blog_post.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cat << EOF > src/pages/posts/___.md
+---
+title: "[wip] ___"
+date: "$(gdate -Iminutes)"
+---
+
+<!-- / -->
+
+EOF


### PR DESCRIPTION
This PR adds a basic build step for generating a blog post skeleton from a template.

It creates a file named `src/pages/posts/___.md` with a YAML heading including a WIP title and a timestamp marking the moment the generation script was ran.