### PR TITLE
Sync page background color with current theme

### DIFF
--- a/src/components/blog_layout.jsx
+++ b/src/components/blog_layout.jsx
@@ -44,11 +44,6 @@ export default ({ children }) => (
             title={data.site.siteMetadata.title}
             link={[{ href: "https://daniel13rady.com/", rel: "canonical" }]}
           />
-          <Global
-            styles={{
-              body: { backgroundColor: darkness.colors.background }
-            }}
-          />
           {children}
         </Root>
       </ThemeProvider>

--- a/src/utils/typography/index.js
+++ b/src/utils/typography/index.js
@@ -3,13 +3,19 @@ import lincoln from "typography-theme-lincoln";
 
 import darkness, { scaleRatio } from "@utils/themes/darkness";
 
-const { header, link, body } = darkness.colors;
+export const theme = darkness;
+
+const { header, link, body, background } = theme.colors;
+// TODO Iterate on this once I have written some actual blog posts.
 const typography = new Typography({
   ...lincoln,
   scaleRatio,
   headerColor: header,
   bodyColor: body,
   overrideThemeStyles: () => ({
+    body: {
+      backgroundColor: background
+    },
     a: {
       color: link,
       backgroundImage: null,


### PR DESCRIPTION
Before:
`theme = dark`
![before](https://user-images.githubusercontent.com/2475919/73176535-95601c80-4104-11ea-86ac-a3275e3e818b.png)

After:
`theme = dark`
![image](https://user-images.githubusercontent.com/2475919/73176523-8da07800-4104-11ea-8c33-ba7e9bfcf2ad.png)
