### PR TITLE
feat(theme): change site theme in response to users' system theme

### DIFF
--- a/src/components/MainLayout.jsx
+++ b/src/components/MainLayout.jsx
@@ -5,7 +5,10 @@ import { Helmet } from "react-helmet";
 import { StaticQuery, graphql } from "gatsby";
 import React from "react";
 
+import useSystemTheme from '@utils/hooks/useSystemTheme';
+
 export default function MainLayout({ children }) {
+  useSystemTheme();
   return (
     <StaticQuery
       query={graphql`

--- a/src/components/MainLayout.jsx
+++ b/src/components/MainLayout.jsx
@@ -5,10 +5,7 @@ import { Helmet } from "react-helmet";
 import { StaticQuery, graphql } from "gatsby";
 import React from "react";
 
-import useSystemTheme from '@utils/hooks/useSystemTheme';
-
 export default function MainLayout({ children }) {
-  useSystemTheme();
   return (
     <StaticQuery
       query={graphql`

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -10,10 +10,15 @@ import {
   IconInstagram,
   IconLinkedIn
 } from "@components/Icons";
+import useSystemTheme from '@utils/hooks/useSystemTheme';
 import useThemeToggle from "@utils/hooks/useThemeToggle";
 
 export default function Home() {
+  // Manual theme toggle (easter egg)
   var toggleTheme = useThemeToggle();
+
+  // Actual theme behavior (respect user's system)
+  useSystemTheme();
 
   return (
     <MainLayout>

--- a/src/pages/wishlist.jsx
+++ b/src/pages/wishlist.jsx
@@ -10,7 +10,7 @@ import StripeBadge from "@components/StripeBadge";
 import MainLayout from "@components/MainLayout";
 import CreditCardForm from "@components/CreditCardForm";
 import useWishlist from "@utils/hooks/useWishlist";
-import useThemeToggle from "@utils/hooks/useThemeToggle";
+import useSystemTheme from '@utils/hooks/useSystemTheme';
 
 function WishlistItem({
   selected,
@@ -148,7 +148,7 @@ function Nothing() {
 // Figure out why and stop it; probably has something to do with component rendering.
 // TODO(dabrady) Consider caching wishlist in session cookie, which is refreshed on donate.
 export default function Wishlist() {
-  var toggleTheme = useThemeToggle();
+  useSystemTheme();
   var spinnerSize = useResponsiveValue([64, 128, 192, 256]);
   var [loaded, setLoaded] = useState(false);
   var [selectedItem, setSelectedItem] = useState(null);
@@ -178,7 +178,7 @@ export default function Wishlist() {
           }
         }}
       >
-        <Heading as="header" onClick={toggleTheme}>
+        <Heading as="header">
           things I want
         </Heading>
         <Flex

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -71,6 +71,7 @@ export default {
   colors: {
     ...palette,
 
+    // TODO(dabrady) Can these go into a 'light' mode?
     text: palette.black,
     background: palette.softWhite,
     // primary,

--- a/src/utils/hooks/useSystemTheme.js
+++ b/src/utils/hooks/useSystemTheme.js
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+/** @jsx jsx */
+import { jsx, useThemeUI } from "theme-ui";
+
+/** Sync site theme with users' system. **/
+export default function useSystemTheme() {
+  var { setColorMode } = useThemeUI();
+  useEffect(function syncThemeWithSystem() {
+    function switchMode(darkMode) {
+      if ( darkMode.matches ) {
+        setColorMode('dark');
+      } else {
+        // TODO(dabrady) This should be called 'light'; what if dark is default?
+        setColorMode('default'/* 'light' */);
+      }
+    }
+
+    // Switch mode when browser detects system theme has changed.
+    var darkModeMediaQuery = window.matchMedia(
+      '(prefers-color-scheme: dark)'
+    );
+    darkModeMediaQuery.addEventListener('change', switchMode);
+
+    // Stop monitoring system theme when component is unmounted.
+    return function stopSwitchingModes() {
+      darkModeMediaQuery.removeEventListener('change', switchMode);
+    };
+  }, [setColorMode]);
+}


### PR DESCRIPTION
The site is currently set to **initialize** its theme based on the user's system settings, but this gets set into local storage and persists across sessions for awhile. That's not the precise behavior I want: I want the site to respect the user's system preferences, in real time.

# Before
![May-13-2021 20-19-08](https://user-images.githubusercontent.com/2475919/118229935-8d76d980-b428-11eb-81c7-fa697d608280.gif)

# After
![May-13-2021 19-58-26](https://user-images.githubusercontent.com/2475919/118229958-9667ab00-b428-11eb-8923-81c8ba79cc9f.gif)
