### PR TITLE
devops: Disable the dev 404 page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,11 @@
+// Disables the dev 404 page. I find it mildly annoying.
+// @see https://github.com/gatsbyjs/gatsby/issues/16112
+exports.onCreatePage = ({ page, actions }) => {
+  if (process.env.NODE_ENV !== `production` && page.path === `/404/`) {
+    const { createPage } = actions;
+    // Make the 404 page match everything client side.
+    // This will be used as fallback if more specific pages are not found
+    page.matchPath = `/*`;
+    createPage(page);
+  }
+};


### PR DESCRIPTION
I don't like seeing this interceptor during development right now:

![image](https://user-images.githubusercontent.com/2475919/224585870-cc3d6581-c66d-4011-8a33-71863a10294e.png)

Perhaps as the breadth of my site grows, I will reconsider. But for now, I'm disabling it via the strategy suggested here: https://github.com/gatsbyjs/gatsby/issues/16112

(There is a plugin, [`gatsby-disable-404`](https://github.com/sbstjn/gatsby-disable-404), which I tried using first, but it didn't work for me: it caused errors instead. It's over 5 years old, so perhaps it simply doesn't work with my version of Gatsby.)